### PR TITLE
Fix login redirect to dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { useRouter } from 'next/navigation'
 import AnimatedGear from "../components/AnimatedGear";
 import {
   Chart,
@@ -33,12 +34,13 @@ interface DashboardData {
 export default function Dashboard() {
   const [role, setRole] = useState<"admin" | "user" | null>(null);
   const [data, setData] = useState<DashboardData | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     if (typeof document === "undefined") return;
     const match = document.cookie.match(/session=([^;]+)/);
     if (!match) {
-      window.location.href = "/";
+      router.replace("/");
       return;
     }
     const [, value] = match;
@@ -125,7 +127,7 @@ export default function Dashboard() {
           className="px-6 py-3 bg-gray-700 hover:bg-gray-900 rounded-lg text-white font-semibold shadow"
           onClick={() => {
             document.cookie = "session=; Max-Age=0; path=/";
-            window.location.href = "/";
+            router.replace("/");
           }}
         >
           Logout

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 
 export default function LoginPage() {
   const [username, setUsername] = useState('')
@@ -7,6 +8,7 @@ export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const router = useRouter()
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
@@ -23,9 +25,7 @@ export default function LoginPage() {
       setLoading(false)
 
       if (res.ok && data.success) {
-        setTimeout(() => {
-          window.location.href = '/dashboard'
-        }, 150)
+        router.push('/dashboard')
       } else {
         setError(data.error || 'Login failed')
       }
@@ -83,7 +83,7 @@ export default function LoginPage() {
           <button
             type="button"
             className="w-full py-2 text-sm text-blue-200 hover:text-blue-400"
-            onClick={() => window.location.href = '/reset'}
+            onClick={() => router.push('/reset')}
           >
             Forgot password?
           </button>


### PR DESCRIPTION
## Summary
- use Next.js router for login success redirect

## Testing
- `npm run lint` *(fails: interactive ESLint prompt)*
- `DATABASE_URL='postgresql://neondb_owner:npg_lve9K0hmnoPN@ep-long-art-aeccf9ci-pooler.c-2.us-east-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require' npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687574c23640832c869eccc92dcec3c0