### PR TITLE
Redesign login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ An example file is included as `.env.example`.
 ## Password reset flow
 
 Visit `/reset` and enter a username. Selecting **Send Code** generates a one‑time code on the server and displays it for demonstration purposes. After receiving the code, enter it together with a new password to complete the reset.
+
+## Demo login system
+
+For a self-contained demonstration that does not rely on the backend APIs, visit `/login-system`. This page showcases a simple login, password reset and dashboard flow implemented entirely on the client side.

--- a/app/login-system/page.tsx
+++ b/app/login-system/page.tsx
@@ -1,0 +1,334 @@
+'use client'
+import React, { useState } from 'react'
+import { Eye, EyeOff, Mail, Lock, ArrowLeft, Check, User, Settings, LogOut } from 'lucide-react'
+
+interface Errors {
+  email?: string
+  password?: string
+  resetEmail?: string
+  general?: string
+}
+
+interface UserRecord {
+  password: string
+  name: string
+}
+
+const users: Record<string, UserRecord> = {
+  'user@example.com': { password: 'password123', name: 'John Doe' },
+  'admin@example.com': { password: 'admin123', name: 'Admin User' }
+}
+
+function validateEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+}
+
+export default function LoginSystem() {
+  const [currentView, setCurrentView] = useState<'login' | 'reset' | 'homepage'>('login')
+  const [formData, setFormData] = useState({ email: '', password: '', resetEmail: '' })
+  const [showPassword, setShowPassword] = useState(false)
+  const [errors, setErrors] = useState<Errors>({})
+  const [loading, setLoading] = useState(false)
+  const [resetSent, setResetSent] = useState(false)
+  const [currentUser, setCurrentUser] = useState<{ email: string; name: string } | null>(null)
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = e.target
+    setFormData(prev => ({ ...prev, [name]: value }))
+    if (errors[name as keyof Errors]) {
+      setErrors(prev => ({ ...prev, [name]: '' }))
+    }
+  }
+
+  function handleLogin(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setErrors({})
+
+    const newErrors: Errors = {}
+    if (!formData.email) {
+      newErrors.email = 'Email is required'
+    } else if (!validateEmail(formData.email)) {
+      newErrors.email = 'Please enter a valid email'
+    }
+
+    if (!formData.password) {
+      newErrors.password = 'Password is required'
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors)
+      setLoading(false)
+      return
+    }
+
+    setTimeout(() => {
+      const user = users[formData.email]
+      if (user && user.password === formData.password) {
+        setCurrentUser({ email: formData.email, name: user.name })
+        setCurrentView('homepage')
+      } else {
+        setErrors({ general: 'Invalid email or password' })
+      }
+      setLoading(false)
+    }, 1000)
+  }
+
+  function handlePasswordReset(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setErrors({})
+
+    if (!formData.resetEmail) {
+      setErrors({ resetEmail: 'Email is required' })
+      setLoading(false)
+      return
+    }
+
+    if (!validateEmail(formData.resetEmail)) {
+      setErrors({ resetEmail: 'Please enter a valid email' })
+      setLoading(false)
+      return
+    }
+
+    setTimeout(() => {
+      setResetSent(true)
+      setLoading(false)
+    }, 1000)
+  }
+
+  function handleLogout() {
+    setCurrentUser(null)
+    setCurrentView('login')
+    setFormData({ email: '', password: '', resetEmail: '' })
+    setErrors({})
+    setResetSent(false)
+  }
+
+  if (currentView === 'reset') {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+        <div className="max-w-md w-full space-y-8">
+          <div className="bg-white rounded-2xl shadow-xl p-8">
+            <div className="text-center mb-8">
+              <div className="mx-auto h-12 w-12 bg-indigo-600 rounded-full flex items-center justify-center mb-4">
+                <Mail className="h-6 w-6 text-white" />
+              </div>
+              <h2 className="text-3xl font-bold text-gray-900">Reset Password</h2>
+              <p className="text-gray-600 mt-2">Enter your email to receive reset instructions</p>
+            </div>
+            {resetSent ? (
+              <div className="text-center">
+                <div className="mx-auto h-16 w-16 bg-green-100 rounded-full flex items-center justify-center mb-4">
+                  <Check className="h-8 w-8 text-green-600" />
+                </div>
+                <h3 className="text-lg font-medium text-gray-900 mb-2">Email Sent!</h3>
+                <p className="text-gray-600 mb-6">We&apos;ve sent password reset instructions to {formData.resetEmail}</p>
+                <button
+                  onClick={() => {
+                    setCurrentView('login')
+                    setResetSent(false)
+                    setFormData(prev => ({ ...prev, resetEmail: '' }))
+                  }}
+                  className="w-full bg-indigo-600 text-white py-3 px-4 rounded-lg font-medium hover:bg-indigo-700 transition-colors"
+                >
+                  Back to Login
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                <div>
+                  <label htmlFor="resetEmail" className="block text-sm font-medium text-gray-700 mb-2">
+                    Email Address
+                  </label>
+                  <div className="relative">
+                    <Mail className="absolute left-3 top-3 h-5 w-5 text-gray-400" />
+                    <input
+                      id="resetEmail"
+                      name="resetEmail"
+                      type="email"
+                      value={formData.resetEmail}
+                      onChange={handleInputChange}
+                      onKeyDown={e => e.key === 'Enter' && handlePasswordReset(e)}
+                      className={`w-full pl-10 pr-4 py-3 border rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none transition-colors ${errors.resetEmail ? 'border-red-500' : 'border-gray-300'}`}
+                      placeholder="Enter your email"
+                    />
+                  </div>
+                  {errors.resetEmail && <p className="mt-1 text-sm text-red-600">{errors.resetEmail}</p>}
+                </div>
+
+                <button
+                  onClick={handlePasswordReset}
+                  disabled={loading}
+                  className="w-full bg-indigo-600 text-white py-3 px-4 rounded-lg font-medium hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {loading ? 'Sending...' : 'Send Reset Instructions'}
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => setCurrentView('login')}
+                  className="w-full flex items-center justify-center text-gray-600 hover:text-gray-800 py-2"
+                >
+                  <ArrowLeft className="h-4 w-4 mr-2" />
+                  Back to Login
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (currentView === 'homepage') {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <header className="bg-white shadow">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex justify-between items-center py-6">
+              <div className="flex items-center">
+                <div className="h-8 w-8 bg-indigo-600 rounded-lg flex items-center justify-center mr-3">
+                  <Lock className="h-5 w-5 text-white" />
+                </div>
+                <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+              </div>
+              <div className="flex items-center space-x-4">
+                <div className="flex items-center space-x-2">
+                  <User className="h-5 w-5 text-gray-500" />
+                  <span className="text-gray-700">{currentUser?.name}</span>
+                </div>
+                <button
+                  onClick={handleLogout}
+                  className="flex items-center space-x-2 text-gray-600 hover:text-gray-800 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors"
+                >
+                  <LogOut className="h-4 w-4" />
+                  <span>Logout</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </header>
+        <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+          <div className="px-4 py-6 sm:px-0">
+            <div className="border-4 border-dashed border-gray-200 rounded-lg p-8">
+              <div className="text-center">
+                <div className="mx-auto h-16 w-16 bg-green-100 rounded-full flex items-center justify-center mb-4">
+                  <Check className="h-8 w-8 text-green-600" />
+                </div>
+                <h2 className="text-3xl font-bold text-gray-900 mb-2">Welcome to Your Dashboard!</h2>
+                <p className="text-gray-600 mb-8">You&apos;ve successfully logged in as {currentUser?.email}</p>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
+                  <div className="bg-white rounded-lg shadow p-6">
+                    <div className="flex items-center justify-between mb-4">
+                      <h3 className="text-lg font-medium text-gray-900">Profile</h3>
+                      <User className="h-5 w-5 text-indigo-600" />
+                    </div>
+                    <p className="text-gray-600">Manage your account settings and preferences</p>
+                  </div>
+                  <div className="bg-white rounded-lg shadow p-6">
+                    <div className="flex items-center justify-between mb-4">
+                      <h3 className="text-lg font-medium text-gray-900">Settings</h3>
+                      <Settings className="h-5 w-5 text-indigo-600" />
+                    </div>
+                    <p className="text-gray-600">Configure your application preferences</p>
+                  </div>
+                  <div className="bg-white rounded-lg shadow p-6">
+                    <div className="flex items-center justify-between mb-4">
+                      <h3 className="text-lg font-medium text-gray-900">Security</h3>
+                      <Lock className="h-5 w-5 text-indigo-600" />
+                    </div>
+                    <p className="text-gray-600">Update your security settings and password</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="bg-white rounded-2xl shadow-xl p-8">
+          <div className="text-center mb-8">
+            <div className="mx-auto h-12 w-12 bg-indigo-600 rounded-full flex items-center justify-center mb-4">
+              <Lock className="h-6 w-6 text-white" />
+            </div>
+            <h2 className="text-3xl font-bold text-gray-900">Welcome Back</h2>
+            <p className="text-gray-600 mt-2">Sign in to your account</p>
+          </div>
+          {errors.general && <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">{errors.general}</div>}
+          <div className="space-y-6">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+                Email Address
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-3 h-5 w-5 text-gray-400" />
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  value={formData.email}
+                  onChange={handleInputChange}
+                  onKeyDown={e => e.key === 'Enter' && handleLogin(e)}
+                  className={`w-full pl-10 pr-4 py-3 border rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none transition-colors ${errors.email ? 'border-red-500' : 'border-gray-300'}`}
+                  placeholder="Enter your email"
+                />
+              </div>
+              {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email}</p>}
+            </div>
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+                Password
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-3 h-5 w-5 text-gray-400" />
+                <input
+                  id="password"
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  value={formData.password}
+                  onChange={handleInputChange}
+                  onKeyDown={e => e.key === 'Enter' && handleLogin(e)}
+                  className={`w-full pl-10 pr-12 py-3 border rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none transition-colors ${errors.password ? 'border-red-500' : 'border-gray-300'}`}
+                  placeholder="Enter your password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                </button>
+              </div>
+              {errors.password && <p className="mt-1 text-sm text-red-600">{errors.password}</p>}
+            </div>
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setCurrentView('reset')}
+                className="text-sm text-indigo-600 hover:text-indigo-500 font-medium"
+              >
+                Forgot your password?
+              </button>
+            </div>
+            <button
+              onClick={handleLogin}
+              disabled={loading}
+              className="w-full bg-indigo-600 text-white py-3 px-4 rounded-lg font-medium hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {loading ? 'Signing in...' : 'Sign In'}
+            </button>
+          </div>
+          <div className="mt-6 text-center">
+            <p className="text-sm text-gray-600">Demo credentials: user@example.com / password123</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,94 +1,151 @@
 'use client'
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { Eye, EyeOff, Mail, Lock } from 'lucide-react'
 
 export default function LoginPage() {
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [showPassword, setShowPassword] = useState(false)
-  const [error, setError] = useState('')
-  const [loading, setLoading] = useState(false)
   const router = useRouter()
+  const [formData, setFormData] = useState({ email: '', password: '' })
+  const [showPassword, setShowPassword] = useState(false)
+  const [errors, setErrors] = useState<{ email?: string; password?: string; general?: string }>({})
+  const [loading, setLoading] = useState(false)
+
+  function validateEmail(email: string) {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+  }
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = e.target
+    setFormData(prev => ({ ...prev, [name]: value }))
+    if (errors[name as 'email' | 'password']) {
+      setErrors(prev => ({ ...prev, [name]: '' }))
+    }
+  }
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
-    setError('')
     setLoading(true)
+    setErrors({})
+
+    const newErrors: { email?: string; password?: string } = {}
+    if (!formData.email) {
+      newErrors.email = 'Email is required'
+    } else if (!validateEmail(formData.email)) {
+      newErrors.email = 'Please enter a valid email'
+    }
+    if (!formData.password) {
+      newErrors.password = 'Password is required'
+    }
+    if (Object.keys(newErrors).length) {
+      setErrors(newErrors)
+      setLoading(false)
+      return
+    }
 
     try {
       const res = await fetch('/api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password })
+        body: JSON.stringify({ username: formData.email, password: formData.password })
       })
       const data = await res.json()
-      setLoading(false)
 
       if (res.ok && data.success) {
         router.push('/dashboard')
       } else {
-        setError(data.error || 'Login failed')
+        setErrors({ general: data.error || 'Invalid credentials' })
       }
     } catch (err) {
-      console.error('Login error:', err)
+      setErrors({ general: 'Something went wrong' })
+    } finally {
       setLoading(false)
-      setError('Something went wrong. Try again.')
     }
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-slate-900 to-blue-950">
-      <div className="w-full max-w-md bg-white/10 backdrop-blur-xl rounded-2xl shadow-xl p-10 border border-white/10">
-        <h1 className="text-4xl font-extrabold text-white text-center mb-8">🔒 Secure Login</h1>
-        <form onSubmit={handleLogin} className="space-y-6">
-          <input
-            type="text"
-            placeholder="Username"
-            className="w-full rounded-lg px-5 py-3 bg-gray-900/80 text-white border border-gray-800 focus:border-blue-500 outline-none text-lg"
-            value={username}
-            onChange={e => setUsername(e.target.value)}
-            required
-            autoFocus
-          />
-          <div className="relative">
-            <input
-              type={showPassword ? 'text' : 'password'}
-              placeholder="Password"
-              className="w-full rounded-lg px-5 py-3 bg-gray-900/80 text-white border border-gray-800 focus:border-blue-500 outline-none text-lg"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              required
-            />
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="bg-white rounded-2xl shadow-xl p-8">
+          <div className="text-center mb-8">
+            <div className="mx-auto h-12 w-12 bg-indigo-600 rounded-full flex items-center justify-center mb-4">
+              <Lock className="h-6 w-6 text-white" />
+            </div>
+            <h2 className="text-3xl font-bold text-gray-900">Welcome Back</h2>
+            <p className="text-gray-600 mt-2">Sign in to your account</p>
+          </div>
+          {errors.general && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">
+              {errors.general}
+            </div>
+          )}
+          <div className="space-y-6">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+                Email Address
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-3 h-5 w-5 text-gray-400" />
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  value={formData.email}
+                  onChange={handleInputChange}
+                  onKeyDown={e => e.key === 'Enter' && handleLogin(e)}
+                  className={`w-full pl-10 pr-4 py-3 border rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none transition-colors ${
+                    errors.email ? 'border-red-500' : 'border-gray-300'
+                  }`}
+                  placeholder="Enter your email"
+                />
+              </div>
+              {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email}</p>}
+            </div>
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+                Password
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-3 h-5 w-5 text-gray-400" />
+                <input
+                  id="password"
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  value={formData.password}
+                  onChange={handleInputChange}
+                  onKeyDown={e => e.key === 'Enter' && handleLogin(e)}
+                  className={`w-full pl-10 pr-12 py-3 border rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none transition-colors ${
+                    errors.password ? 'border-red-500' : 'border-gray-300'
+                  }`}
+                  placeholder="Enter your password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                </button>
+              </div>
+              {errors.password && <p className="mt-1 text-sm text-red-600">{errors.password}</p>}
+            </div>
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => router.push('/reset')}
+                className="text-sm text-indigo-600 hover:text-indigo-500 font-medium"
+              >
+                Forgot your password?
+              </button>
+            </div>
             <button
-              type="button"
-              tabIndex={-1}
-              onClick={() => setShowPassword(v => !v)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white"
-              aria-label={showPassword ? 'Hide password' : 'Show password'}
+              onClick={handleLogin}
+              disabled={loading}
+              className="w-full bg-indigo-600 text-white py-3 px-4 rounded-lg font-medium hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
-              {showPassword ? (
-                <svg width="22" height="22" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" strokeWidth="2" d="M3 3l18 18m-1.41-1.41A9.963 9.963 0 0 1 12 21C6.48 21 2 12 2 12a20.61 20.61 0 0 1 5.13-7.06M10.36 6.37A5.978 5.978 0 0 1 12 6c5.52 0 10 9 10 9a20.612 20.612 0 0 1-4.29 5.29"/></svg>
-              ) : (
-                <svg width="22" height="22" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" strokeWidth="2" d="M1 12S6.48 3 12 3s11 9 11 9-4.48 9-11 9S1 12 1 12z"/><circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="2"/></svg>
-              )}
+              {loading ? 'Signing in...' : 'Sign In'}
             </button>
           </div>
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full py-3 rounded-lg bg-blue-600 hover:bg-blue-800 font-bold text-white text-lg"
-          >
-            {loading ? 'Signing in…' : 'Login'}
-          </button>
-          <button
-            type="button"
-            className="w-full py-2 text-sm text-blue-200 hover:text-blue-400"
-            onClick={() => router.push('/reset')}
-          >
-            Forgot password?
-          </button>
-          {error && <div className="text-center text-red-300 mt-2">{error}</div>}
-        </form>
+        </div>
       </div>
     </div>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@neondatabase/serverless": "^0.6.1",
         "chart.js": "^4.5.0",
+        "lucide-react": "^0.525.0",
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
@@ -3887,6 +3888,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "lucide-react": "^0.525.0"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Summary
- polish the default login page with improved styling and icons
- validate email input and send credentials to `/api/login`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68765c37728c832cb7295641e551b1d4