### PR TITLE
Add Neon server action

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Database connection string
-DATABASE_URL="postgres://user:password@host/db"
+# When using Neon this typically includes SSL requirements
+DATABASE_URL="postgresql://user:password@host/db?sslmode=require&channel_binding=require"
 
 # Optional initial admin credentials used by npm run init-db
 INITIAL_ADMIN_USER="admin"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ INITIAL_ADMIN_USER=admin
 INITIAL_ADMIN_PASSWORD=changeme
 ```
 
+
 Run `npm run init-db` once to create the necessary tables and optionally seed the first admin user.
+
+## Server actions
+
+The `app/actions.ts` file contains server-only functions. These actions run in
+Node.js and can safely access environment variables like `DATABASE_URL` without
+leaking them to the browser. The example `getData()` function returns a list of
+users from the database using the Neon serverless driver.
 
 
 ## Password reset flow

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,0 +1,10 @@
+"use server";
+import { neon } from "@neondatabase/serverless";
+
+const sql = neon(process.env.DATABASE_URL!);
+
+export async function getData() {
+  // Return a list of all users from the database
+  const rows = await sql`SELECT id, username, role FROM users ORDER BY id`;
+  return rows as { id: number; username: string; role: string }[];
+}


### PR DESCRIPTION
## Summary
- create `app/actions.ts` for server-only database access
- update environment example with Neon connection format
- document new server actions in README

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876a036498c832cafa3acff428491fe